### PR TITLE
Add support for TCN architectures as described in "User-Driven Fine-Tuning for Beat Tracking" by Pinto et al., 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ model = TCN(
     output_projection: Optional[ int ] = None,
     output_activation: Optional[ str ] = None,
     force_residual_conv: bool = False,
+    use_separate_skip_connection_output: bool = False,
 )
 # Continue to train/use model for your task
 ```
@@ -72,7 +73,8 @@ The order of output dimensions will be the same as for the input tensors.
 - `lookahead`: If not 0, causal TCNs will use a lookahead on future time frames to increase the modelling accuracy. The lookahead parameter specifies the number of future time steps that will be processed influence the prediction for a specific time step. Default is 0. Will be ignored for non-causal networks which already have the maximum lookahead possible.
 - `output_projection`: If not None, the output of the TCN will be projected to the specified dimension via a 1x1 convolution. This may be useful if the output of the TCN is supposed to be of a different dimension than the input or if the last activation should be linear. If None, no projection will be performed. The default is 'None'.
 - `output_activation`: If not None, the output of the TCN will be passed through the specified activation function. This maybe useful to etablish a classification head via softmax etc. If None, no activation will be performed. The default is 'None'.
-- `force_residual_conv`: If 'True', the optional 1x1 Convolution will always be calculated on the residual of each TCN block, even if the amount of input and output channels of the TCN block are identical.
+- `force_residual_conv`: If 'True', the optional 1x1 Convolution will always be calculated on the residual of each TCN block, even if the amount of input and output channels of the TCN block are identical. The default is 'False'.
+- `use_separate_skip_connection_output`: Determines whether the outputs of the skip connections should be secondary output (if 'True') in addition to the regular output of the TNC or whether the output of the skip connections should be primary output (if 'False'). This flag only has an effect if parameter use_skip_connections is 'True'. The default is 'False'.
 
 ## Streaming Inference
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ model = TCN(
     lookahead: int = 0,
     output_projection: Optional[ int ] = None,
     output_activation: Optional[ str ] = None,
+    force_residual_conv: bool = False,
 )
 # Continue to train/use model for your task
 ```
@@ -56,7 +57,7 @@ The order of output dimensions will be the same as for the input tensors.
 - `num_inputs`: The number of input channels, should be equal to the feature dimension of your data.
 - `num_channels`: A list or array that contains the number of feature channels in each residual block of the network.
 - `kernel_size`: The size of the convolution kernel used by the convolutional layers. Good starting points may be 2-8. If the prediction task requires large context sizes, larger kernel size values may be appropriate.
-- `dilations`: If None, the dilation sizes will be calculated via 2^(1...n) for the residual blocks 1 to n. This is the standard way to do it. However, if you need a custom list of dilation sizes for whatever reason you could pass such a list or array to the argument.
+- `dilations`: If None, the dilation sizes will be calculated via 2^(1...n) for the residual blocks 1 to n. This is the standard way to do it. However, if you need a custom list of dilation sizes for whatever reason you could pass such a list or array to the argument. Elements of this arraylike argument may either be a single integer or another arraylike. If an element is a single integer, the corresponding TCN block will have a network architecture as described in figure 1b) of [Bai et al.](https://arxiv.org/abs/1803.01271). If an element is itself an arraylike, the corresponding TCN block will have an architecture similar to what is described in figure 2 of [Pinto et al.](https://www.mdpi.com/2079-9292/10/13/1518#) with multiple dilated convolutions of different dilation rates within the same TCN block.
 - `dilation_reset`: For deep TCNs the dilation size should be reset periodically, otherwise it grows exponentially and the corresponding padding becomes so large that memory overflow occurs (see [Van den Oord et al.](https://arxiv.org/pdf/1609.03499.pdf)). E.g. 'dilation_reset=16' would reset the dilation size once it reaches a value of 16, so the dilation sizes would look like this: [ 1, 2, 4, 8, 16, 1, 2, 4, ...].
 - `dropout`: Is a float value between 0 and 1 that indicates the amount of inputs which are randomly set to zero during training. Usually, 0.1 is a good starting point.
 - `causal`: If 'True', the dilated convolutions will be causal, which means that future information is ignored in the prediction task. This is important for real-time predictions. If set to 'False', future context will be considered for predictions.
@@ -71,6 +72,7 @@ The order of output dimensions will be the same as for the input tensors.
 - `lookahead`: If not 0, causal TCNs will use a lookahead on future time frames to increase the modelling accuracy. The lookahead parameter specifies the number of future time steps that will be processed influence the prediction for a specific time step. Default is 0. Will be ignored for non-causal networks which already have the maximum lookahead possible.
 - `output_projection`: If not None, the output of the TCN will be projected to the specified dimension via a 1x1 convolution. This may be useful if the output of the TCN is supposed to be of a different dimension than the input or if the last activation should be linear. If None, no projection will be performed. The default is 'None'.
 - `output_activation`: If not None, the output of the TCN will be passed through the specified activation function. This maybe useful to etablish a classification head via softmax etc. If None, no activation will be performed. The default is 'None'.
+- `force_residual_conv`: If 'True', the optional 1x1 Convolution will always be calculated on the residual of each TCN block, even if the amount of input and output channels of the TCN block are identical.
 
 ## Streaming Inference
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ model = TCN(
     output_activation: Optional[ str ] = None,
     force_residual_conv: bool = False,
     use_separate_skip_connection_output: bool = False,
+    skip_connection_operation: str = 'sum'
 )
 # Continue to train/use model for your task
 ```
@@ -75,6 +76,7 @@ The order of output dimensions will be the same as for the input tensors.
 - `output_activation`: If not None, the output of the TCN will be passed through the specified activation function. This maybe useful to etablish a classification head via softmax etc. If None, no activation will be performed. The default is 'None'.
 - `force_residual_conv`: If 'True', the optional 1x1 Convolution will always be calculated on the residual of each TCN block, even if the amount of input and output channels of the TCN block are identical. The default is 'False'.
 - `use_separate_skip_connection_output`: Determines whether the outputs of the skip connections should be secondary output (if 'True') in addition to the regular output of the TNC or whether the output of the skip connections should be primary output (if 'False'). This flag only has an effect if parameter use_skip_connections is 'True'. The default is 'False'.
+- `skip_connection_operation`: The operation to apply when combining the skip connection outputs. Can be 'sum' or 'concat'. When set to 'sum', the skip outputs of each layer are summed per channel. When set to 'stack', the skip outputs of each layer are concatenated, resulting in an output with an amount of channels equal to the sum of parameter num_channels. The default is 'sum'.
 
 ## Streaming Inference
 

--- a/pytorch_tcn/tcn.py
+++ b/pytorch_tcn/tcn.py
@@ -318,10 +318,10 @@ class TemporalBlock(nn.Module):
         n_multiplier_gate = 2 if self.use_gate else 1
         conv1d_n_outputs = n_multiplier_gate * n_outputs
 
-        self.conv1 = []
+        conv1 = []
         for i in range(len(dilation)):
             if self.causal:
-                self.conv1 += [
+                conv1 += [
                     CausalConv1d(
                         in_channels=n_inputs,
                         out_channels=conv1d_n_outputs,
@@ -332,7 +332,7 @@ class TemporalBlock(nn.Module):
                     )
                 ]
             else:
-                self.conv1 += [
+                conv1 += [
                     TemporalConv1d(
                         in_channels=n_inputs,
                         out_channels=conv1d_n_outputs,
@@ -377,11 +377,13 @@ class TemporalBlock(nn.Module):
         elif use_norm == 'weight_norm':
             self.norm1 = None
             self.norm2 = None
-            self.conv1 = [weight_norm(self.conv1[i]) for i in range(len(dilation))]
+            conv1 = [weight_norm(conv1[i]) for i in range(len(dilation))]
             self.conv2 = weight_norm(self.conv2)
         elif use_norm is None:
             self.norm1 = None
             self.norm2 = None
+
+        self.conv1 = nn.ModuleList(conv1)
 
         if isinstance( self.activation, str ):
             self.activation1 = activation_fn[ self.activation ]()

--- a/tests/unit/test_tcn.py
+++ b/tests/unit/test_tcn.py
@@ -71,6 +71,9 @@ class TestTCN(unittest.TestCase):
                 kwargs = dict(
                     dilations = [
                         [1, 2, 3, 4, 1, 2, 3, 4],
+                        [[1, 2], [2, 4], [3, 6], [4, 8], [1, 2], [2, 4], [3, 6], [4, 8]],
+                        [[1, 2], [2, 4], [3, 6], [4, 8], 1, 2, 3, 4],
+                        [1, 2, 3, 4, [1, 2], [2, 4], [3, 6], [4, 8]],
                         None,
                     ],
                 ),
@@ -161,6 +164,11 @@ class TestTCN(unittest.TestCase):
                     use_gate = [True, False],
                 ),
                 expected_error = ValueError,
+            ),
+            # Test different values for force_residual_conv
+            dict(
+                kwargs = dict( force_residual_conv = [True, False] ),
+                expected_error = None,
             ),
         ]
 

--- a/tests/unit/test_tcn.py
+++ b/tests/unit/test_tcn.py
@@ -23,6 +23,7 @@ def generate_combinations(test_args):
                 dict(
                     kwargs = combination_dict,
                     expected_error = x['expected_error'],
+                    expected_outputs = x.get('expected_outputs')
                     )
                 )
 
@@ -170,13 +171,38 @@ class TestTCN(unittest.TestCase):
                 kwargs = dict( force_residual_conv = [True, False] ),
                 expected_error = None,
             ),
+            # Test different values for use_separate_skip_connection_output
+            dict(
+                kwargs = dict(
+                    use_skip_connections = [True],
+                    use_separate_skip_connection_output = [True]
+                ),
+                expected_error = None,
+                expected_outputs = 2
+            ),
+            dict(
+                kwargs=dict(
+                    use_skip_connections = [True, False],
+                    use_separate_skip_connection_output = [False]
+                ),
+                expected_error = None,
+                expected_outputs = 1
+            ),
+            dict(
+                kwargs=dict(
+                    use_skip_connections = [False],
+                    use_separate_skip_connection_output = [True]
+                ),
+                expected_error = None,
+                expected_outputs = 1
+            ),
         ]
 
         self.combinations = generate_combinations(self.test_args)
 
         return
 
-    def test_tcn(self, **kwargs):
+    def test_tcn(self, expected_outputs=None, **kwargs):
 
         tcn = TCN(
             num_inputs = self.num_inputs,
@@ -258,8 +284,11 @@ class TestTCN(unittest.TestCase):
             embeddings_inference = None
 
         y = tcn(x, embeddings = embeddings)
-        
-        self.assertEqual( y.shape, expected_shape )
+        if expected_outputs is None or expected_outputs == 1:
+            self.assertEqual( y.shape, expected_shape )
+        else:
+            for i in range(expected_outputs):
+                self.assertEqual( y[i].shape, expected_shape )
 
         # Testing the streaming inference mode for causal models
         if tcn.causal:
@@ -277,8 +306,12 @@ class TestTCN(unittest.TestCase):
                     )
                 #print( 'y_inference shape: ', y_inference.shape)
                 #stop
-                
-            self.assertEqual( y_inference.shape, expected_shape_inference )
+
+            if expected_outputs is None or expected_outputs == 1:
+                self.assertEqual(y_inference.shape, expected_shape_inference)
+            else:
+                for i in range(expected_outputs):
+                    self.assertEqual(y_inference[i].shape, expected_shape_inference)
 
             # piecewise inference:
             tcn.reset_buffers()
@@ -322,8 +355,13 @@ class TestTCN(unittest.TestCase):
                             embeddings = embeddings_frame,
                             )
                     )
-            y_inference_frames = torch.cat( y_inference_frames, dim = time_dimension )
-            self.assertEqual( y_inference_frames.shape, expected_shape_inference )
+            if expected_outputs is None or expected_outputs == 1:
+                y_inference_frames = torch.cat(y_inference_frames, dim=time_dimension)
+                self.assertEqual(y_inference_frames.shape, expected_shape_inference)
+            else:
+                for i in range(expected_outputs):
+                    y_inference_concatenated = torch.cat([frame[i] for frame in y_inference_frames], dim=time_dimension)
+                    self.assertEqual(y_inference_concatenated.shape, expected_shape_inference)
             #stop
 
             ## piecewise inference without buffer
@@ -361,10 +399,10 @@ class TestTCN(unittest.TestCase):
             kwargs = test_dict['kwargs']
             print( 'Testing kwargs: ', kwargs )
             if test_dict['expected_error'] is None:
-                self.test_tcn( **kwargs )
+                self.test_tcn(test_dict.get('expected_outputs'), **kwargs )
             else:
                 with self.assertRaises(test_dict['expected_error']):
-                    self.test_tcn( **kwargs )
+                    self.test_tcn(test_dict.get('expected_outputs'), **kwargs )
 
         return
     

--- a/tests/unit/test_tcn.py
+++ b/tests/unit/test_tcn.py
@@ -196,6 +196,21 @@ class TestTCN(unittest.TestCase):
                 expected_error = None,
                 expected_outputs = 1
             ),
+            # Test different values for skip_connection_operation
+            dict(
+                kwargs=dict(
+                    use_skip_connections = [True],
+                    skip_connection_operation = ['sum', 'concat']
+                ),
+                expected_error=None,
+            ),
+            dict(
+                kwargs=dict(
+                    use_skip_connections = [True],
+                    skip_connection_operation = ['foo']
+                ),
+                expected_error = ValueError,
+            ),
         ]
 
         self.combinations = generate_combinations(self.test_args)
@@ -218,9 +233,11 @@ class TestTCN(unittest.TestCase):
             self.num_inputs,
             self.time_steps,
             )
+        is_skip_operation_concat = (kwargs.get('use_skip_connections', False)
+                                    and kwargs.get('skip_connection_operation', 'sum') == 'concat')
         expected_shape = (
             self.batch_size,
-            self.num_channels[-1],
+            sum(self.num_channels) if is_skip_operation_concat else self.num_channels[-1],
             self.time_steps,
             )
         x_inference = torch.randn(
@@ -230,7 +247,7 @@ class TestTCN(unittest.TestCase):
             )
         expected_shape_inference = (
             1,
-            self.num_channels[-1],
+            sum(self.num_channels) if is_skip_operation_concat else self.num_channels[-1],
             self.time_steps - tcn.lookahead,
             )
 


### PR DESCRIPTION
This PR adds support for TCN architectures as described in the paper ["User-Driven Fine-Tuning for Beat Tracking"](https://www.mdpi.com/2079-9292/10/13/1518) by Pinto et al., 2021. Within this network architecture, the authors propose the usage of a TCN where each TCN layer uses two separate sets of dilated convolutions, where one of the dilated convolutions has a dilation of twice that of the first dilated convolution.

Implements the functionality suggested in issue #14.